### PR TITLE
Make sure tests pass in any culture and extract words using unicode categories

### DIFF
--- a/CaseConverter/Converters/StringCaseConverter.cs
+++ b/CaseConverter/Converters/StringCaseConverter.cs
@@ -108,7 +108,7 @@ namespace CaseConverter.Converters
                 return Enumerable.Empty<string>();
             }
 
-            return Regex.Matches(input, @"[a-z\d]+|[A-Z\d]+(?![A-Za-z\d])|[A-Z\d]+(?=[A-Z])|[A-Z][a-z\d]*").GetValues();
+            return Regex.Matches(input, @"[\p{Ll}\d]+|[\p{Lu}\d]+(?![\p{L}\d])|[\p{Lu}\d]+(?=\p{Lu})|\p{Lu}[\p{Ll}\d]*").GetValues();
         }
 
         /// <summary>

--- a/Test.CaseConverter/Converters/CamelCaseConverterTest.cs
+++ b/Test.CaseConverter/Converters/CamelCaseConverterTest.cs
@@ -14,5 +14,11 @@ namespace Test.CaseConverter.Converters
         {
             ConvertTest("hogeFugaPiyo", "hoge", "h");
         }
+
+        [TestMethod]
+        public void ConvertTestTR()
+        {
+            ConvertTestTR("saçımŞekilÖnümdenÇekil", "şekil", "i");
+        }
     }
 }

--- a/Test.CaseConverter/Converters/CaseConverterTestBase.cs
+++ b/Test.CaseConverter/Converters/CaseConverterTestBase.cs
@@ -15,21 +15,24 @@ namespace Test.CaseConverter.Converters
         /// </summary>
         protected void ConvertTest(string multiWords, string singleWord, string singleCharacter)
         {
-            var converter = new TConverter();
-            Action<string, string[]> assert = (expected, source) =>
-                Assert.AreEqual(expected, converter.Convert(source));
+            using (new CultureInfoContext("en-US"))
+            {
+                var converter = new TConverter();
+                Action<string, string[]> assert = (expected, source) =>
+                    Assert.AreEqual(expected, converter.Convert(source));
 
-            assert(multiWords, new[] { "hoge", "fuga", "piyo" });
-            assert(multiWords, new[] { "HOGE", "fuga", "piyo" });
+                assert(multiWords, new[] { "hoge", "fuga", "piyo" });
+                assert(multiWords, new[] { "HOGE", "fuga", "piyo" });
 
-            assert(singleWord, new[] { "hoge" });
-            assert(singleWord, new[] { "HOGE" });
+                assert(singleWord, new[] { "hoge" });
+                assert(singleWord, new[] { "HOGE" });
 
-            assert(singleCharacter, new[] { "h" });
-            assert(singleCharacter, new[] { "H" });
+                assert(singleCharacter, new[] { "h" });
+                assert(singleCharacter, new[] { "H" });
 
-            assert(string.Empty, null);
-            assert(string.Empty, new string[0]);
+                assert(string.Empty, null);
+                assert(string.Empty, new string[0]);
+            }
         }
     }
 }

--- a/Test.CaseConverter/Converters/CaseConverterTestBase.cs
+++ b/Test.CaseConverter/Converters/CaseConverterTestBase.cs
@@ -34,5 +34,30 @@ namespace Test.CaseConverter.Converters
                 assert(string.Empty, new string[0]);
             }
         }
+
+        /// <summary>
+        /// <see cref="ICaseConverter.Convert"/>をテストします。
+        /// </summary>
+        protected void ConvertTestTR(string multiWords, string singleWord, string singleCharacter)
+        {
+            using (new CultureInfoContext("tr-TR"))
+            {
+                var converter = new TConverter();
+                Action<string, string[]> assert = (expected, source) =>
+                    Assert.AreEqual(expected, converter.Convert(source));
+
+                assert(multiWords, new[] { "saçım", "şekil", "önümden", "çekil" });
+                assert(multiWords, new[] { "SAÇIM", "ŞEKİL", "ÖNÜMDEN", "çekil" });
+
+                assert(singleWord, new[] { "şekil" });
+                assert(singleWord, new[] { "ŞEKİL" });
+
+                assert(singleCharacter, new[] { "i" });
+                assert(singleCharacter, new[] { "İ" });
+
+                assert(string.Empty, null);
+                assert(string.Empty, new string[0]);
+            }
+        }
     }
 }

--- a/Test.CaseConverter/Converters/KebabCaseConverterTest.cs
+++ b/Test.CaseConverter/Converters/KebabCaseConverterTest.cs
@@ -14,5 +14,11 @@ namespace Test.CaseConverter.Converters
         {
             ConvertTest("hoge-fuga-piyo", "hoge", "h");
         }
+
+        [TestMethod]
+        public void ConvertTestTR()
+        {
+            ConvertTestTR("saçım-şekil-önümden-çekil", "şekil", "i");
+        }
     }
 }

--- a/Test.CaseConverter/Converters/PascalCaseConverterTest.cs
+++ b/Test.CaseConverter/Converters/PascalCaseConverterTest.cs
@@ -14,5 +14,11 @@ namespace Test.CaseConverter.Converters
         {
             ConvertTest("HogeFugaPiyo", "Hoge", "H");
         }
+
+        [TestMethod]
+        public void ConvertTestTR()
+        {
+            ConvertTestTR("SaçımŞekilÖnümdenÇekil", "Şekil", "İ");
+        }
     }
 }

--- a/Test.CaseConverter/Converters/PascalSnakeCaseConverterTest.cs
+++ b/Test.CaseConverter/Converters/PascalSnakeCaseConverterTest.cs
@@ -14,5 +14,11 @@ namespace Test.CaseConverter.Converters
         {
             ConvertTest("Hoge_Fuga_Piyo", "Hoge", "H");
         }
+
+        [TestMethod]
+        public void ConvertTestTR()
+        {
+            ConvertTestTR("Saçım_Şekil_Önümden_Çekil", "Şekil", "İ");
+        }
     }
 }

--- a/Test.CaseConverter/Converters/ScreamingSnakeCaseConverterTest.cs
+++ b/Test.CaseConverter/Converters/ScreamingSnakeCaseConverterTest.cs
@@ -14,5 +14,11 @@ namespace Test.CaseConverter.Converters
         {
             ConvertTest("HOGE_FUGA_PIYO", "HOGE", "H");
         }
+
+        [TestMethod]
+        public void ConvertTestTR()
+        {
+            ConvertTestTR("SAÇIM_ŞEKİL_ÖNÜMDEN_ÇEKİL", "ŞEKİL", "İ");
+        }
     }
 }

--- a/Test.CaseConverter/Converters/SnakeCaseConverterTest.cs
+++ b/Test.CaseConverter/Converters/SnakeCaseConverterTest.cs
@@ -14,5 +14,11 @@ namespace Test.CaseConverter.Converters
         {
             ConvertTest("hoge_fuga_piyo", "hoge", "h");
         }
+
+        [TestMethod]
+        public void ConvertTestTR()
+        {
+            ConvertTestTR("saçım_şekil_önümden_çekil", "şekil", "i");
+        }
     }
 }

--- a/Test.CaseConverter/Converters/StringCaseConverterTest.cs
+++ b/Test.CaseConverter/Converters/StringCaseConverterTest.cs
@@ -15,120 +15,129 @@ namespace Test.CaseConverter.Converters
         [TestMethod]
         public void ConvertTest()
         {
-            var convertPatterns = new List<StringCasePattern>
+            using (new CultureInfoContext("en-US"))
             {
-                StringCasePattern.CamelCase,
-                StringCasePattern.PascalCase,
-                StringCasePattern.SnakeCase
-            };
+                var convertPatterns = new List<StringCasePattern>
+                {
+                    StringCasePattern.CamelCase,
+                    StringCasePattern.PascalCase,
+                    StringCasePattern.SnakeCase
+                };
 
-            Action<string, string> assert = (expected, source) =>
-                Assert.AreEqual(expected, StringCaseConverter.Convert(source, convertPatterns));
+                Action<string, string> assert = (expected, source) =>
+                    Assert.AreEqual(expected, StringCaseConverter.Convert(source, convertPatterns));
 
-            assert("hogeFugaPiyo", "hoge_fuga_piyo");
-            assert("HogeFugaPiyo", "hogeFugaPiyo");
-            assert("hoge_fuga_piyo", "HogeFugaPiyo");
+                assert("hogeFugaPiyo", "hoge_fuga_piyo");
+                assert("HogeFugaPiyo", "hogeFugaPiyo");
+                assert("hoge_fuga_piyo", "HogeFugaPiyo");
 
-            assert(null, null);
-            assert(string.Empty, string.Empty);
-            assert(" ", " ");
-            assert("123", "123");
-            assert("+-*", "+-*");
+                assert(null, null);
+                assert(string.Empty, string.Empty);
+                assert(" ", " ");
+                assert("123", "123");
+                assert("+-*", "+-*");
 
-            Assert.AreEqual("hoge_fuga_piyo", StringCaseConverter.Convert("hoge_fuga_piyo", null));
-            Assert.AreEqual("hoge_fuga_piyo", StringCaseConverter.Convert("hoge_fuga_piyo", new List<StringCasePattern>()));
+                Assert.AreEqual("hoge_fuga_piyo", StringCaseConverter.Convert("hoge_fuga_piyo", null));
+                Assert.AreEqual("hoge_fuga_piyo", StringCaseConverter.Convert("hoge_fuga_piyo", new List<StringCasePattern>()));
+            }
         }
 
         [TestMethod]
         public void GetCasePatternTest()
         {
-            Action<StringCasePattern, string> assert = (expected, source) =>
-                Assert.AreEqual(expected, StringCaseConverter.GetCasePattern(source));
+            using (new CultureInfoContext("en-US"))
+            {
+                Action<StringCasePattern, string> assert = (expected, source) =>
+                    Assert.AreEqual(expected, StringCaseConverter.GetCasePattern(source));
 
-            assert(StringCasePattern.CamelCase, "hogeFugaPiyo");
-            assert(StringCasePattern.PascalCase, "HogeFugaPiyo");
-            assert(StringCasePattern.SnakeCase, "hoge_fuga_piyo");
-            assert(StringCasePattern.PascalSnakeCase, "Hoge_Fuga_Piyo");
-            assert(StringCasePattern.ScreamingSnakeCase, "HOGE_FUGA_PIYO");
-            assert(StringCasePattern.KebabCase, "hoge-fuga-piyo");
+                assert(StringCasePattern.CamelCase, "hogeFugaPiyo");
+                assert(StringCasePattern.PascalCase, "HogeFugaPiyo");
+                assert(StringCasePattern.SnakeCase, "hoge_fuga_piyo");
+                assert(StringCasePattern.PascalSnakeCase, "Hoge_Fuga_Piyo");
+                assert(StringCasePattern.ScreamingSnakeCase, "HOGE_FUGA_PIYO");
+                assert(StringCasePattern.KebabCase, "hoge-fuga-piyo");
 
-            assert(StringCasePattern.CamelCase, "hoge");
-            assert(StringCasePattern.PascalCase, "Hoge");
-            assert(StringCasePattern.ScreamingSnakeCase, "HOGE");
+                assert(StringCasePattern.CamelCase, "hoge");
+                assert(StringCasePattern.PascalCase, "Hoge");
+                assert(StringCasePattern.ScreamingSnakeCase, "HOGE");
 
-            assert(StringCasePattern.CamelCase, "h");
-            assert(StringCasePattern.PascalCase, "H");
+                assert(StringCasePattern.CamelCase, "h");
+                assert(StringCasePattern.PascalCase, "H");
 
-            assert(StringCasePattern.SnakeCase, "_");
-            assert(StringCasePattern.KebabCase, "-");
-            assert(StringCasePattern.CamelCase, "=");
+                assert(StringCasePattern.SnakeCase, "_");
+                assert(StringCasePattern.KebabCase, "-");
+                assert(StringCasePattern.CamelCase, "=");
 
-            assert(StringCasePattern.SnakeCase, "h_");
-            assert(StringCasePattern.SnakeCase, "h_H");
-            assert(StringCasePattern.PascalSnakeCase, "Ho_");
-            assert(StringCasePattern.ScreamingSnakeCase, "H_");
-            assert(StringCasePattern.KebabCase, "H-");
+                assert(StringCasePattern.SnakeCase, "h_");
+                assert(StringCasePattern.SnakeCase, "h_H");
+                assert(StringCasePattern.PascalSnakeCase, "Ho_");
+                assert(StringCasePattern.ScreamingSnakeCase, "H_");
+                assert(StringCasePattern.KebabCase, "H-");
 
-            assert(StringCasePattern.SnakeCase, "_h_");
-            assert(StringCasePattern.SnakeCase, "_Ho_");
-            assert(StringCasePattern.ScreamingSnakeCase, "_H_");
-            assert(StringCasePattern.SnakeCase, "_h-");
+                assert(StringCasePattern.SnakeCase, "_h_");
+                assert(StringCasePattern.SnakeCase, "_Ho_");
+                assert(StringCasePattern.ScreamingSnakeCase, "_H_");
+                assert(StringCasePattern.SnakeCase, "_h-");
 
-            assert(StringCasePattern.CamelCase, string.Empty);
+                assert(StringCasePattern.CamelCase, string.Empty);
+            }
         }
 
         [TestMethod]
         public void GetWordsTest()
         {
-            Action<string[], string> assert = (expected, source) =>
-                CollectionAssert.AreEquivalent(expected, StringCaseConverter.GetWords(source).ToArray());
+            using (new CultureInfoContext("en-US"))
+            {
+                Action<string[], string> assert = (expected, source) =>
+                    CollectionAssert.AreEquivalent(expected, StringCaseConverter.GetWords(source).ToArray());
 
-            assert(new[] { "Hoge", "Fuga", "Piyo" }, "HogeFugaPiyo");
-            assert(new[] { "hoge", "Fuga", "Piyo" }, "hogeFugaPiyo");
-            assert(new[] { "HOGE", "Fuga", "Piyo" }, "HOGEFugaPiyo");
-            assert(new[] { "Hoge", "Fuga", "PIYO" }, "HogeFugaPIYO");
-            assert(new[] { "Hoge", "Fuga", "P" }, "HogeFugaP");
+                assert(new[] { "Hoge", "Fuga", "Piyo" }, "HogeFugaPiyo");
+                assert(new[] { "hoge", "Fuga", "Piyo" }, "hogeFugaPiyo");
+                assert(new[] { "HOGE", "Fuga", "Piyo" }, "HOGEFugaPiyo");
+                assert(new[] { "Hoge", "Fuga", "PIYO" }, "HogeFugaPIYO");
+                assert(new[] { "Hoge", "Fuga", "P" }, "HogeFugaP");
 
-            // MEMO : 数字を含んだテスト
-            assert(new[] { "Hoge", "Fu1ga", "Piyo" }, "HogeFu1gaPiyo");
-            assert(new[] { "ho1ge2", "Fuga", "Piyo" }, "ho1ge2FugaPiyo");
-            assert(new[] { "Hoge", "Fuga1", "PI2YO3" }, "HogeFuga1PI2YO3");
-            assert(new[] { "Hoge", "FU1GA", "Piyo" }, "HogeFU1GAPiyo");
-            assert(new[] { "123" }, "123");
+                // MEMO : 数字を含んだテスト
+                assert(new[] { "Hoge", "Fu1ga", "Piyo" }, "HogeFu1gaPiyo");
+                assert(new[] { "ho1ge2", "Fuga", "Piyo" }, "ho1ge2FugaPiyo");
+                assert(new[] { "Hoge", "Fuga1", "PI2YO3" }, "HogeFuga1PI2YO3");
+                assert(new[] { "Hoge", "FU1GA", "Piyo" }, "HogeFU1GAPiyo");
+                assert(new[] { "123" }, "123");
 
-            // MEMO : 1単語のテスト
-            assert(new[] { "hoge" }, "hoge");
-            assert(new[] { "HOGE" }, "HOGE");
-            assert(new[] { "ho1ge2" }, "ho1ge2");
-            assert(new[] { "1hoge" }, "1hoge");
-            assert(new[] { "1", "HOGE" }, "1HOGE");
+                // MEMO : 1単語のテスト
+                assert(new[] { "hoge" }, "hoge");
+                assert(new[] { "HOGE" }, "HOGE");
+                assert(new[] { "ho1ge2" }, "ho1ge2");
+                assert(new[] { "1hoge" }, "1hoge");
+                assert(new[] { "1", "HOGE" }, "1HOGE");
 
-            // MEMO : 空白を含んだテスト
-            assert(new[] { "Hoge", "Fuga", "Piyo" }, "Hoge Fuga Piyo");
-            assert(new[] { "Hoge", "Fuga", "Piyo" }, "Hoge FugaPiyo");
-            assert(new[] { "hoge", "fuga", "Piyo" }, "hoge fuga Piyo");
-            assert(new[] { "hoge", "fuga", "Piyo" }, "hoge fugaPiyo");
+                // MEMO : 空白を含んだテスト
+                assert(new[] { "Hoge", "Fuga", "Piyo" }, "Hoge Fuga Piyo");
+                assert(new[] { "Hoge", "Fuga", "Piyo" }, "Hoge FugaPiyo");
+                assert(new[] { "hoge", "fuga", "Piyo" }, "hoge fuga Piyo");
+                assert(new[] { "hoge", "fuga", "Piyo" }, "hoge fugaPiyo");
 
-            // MEMO : スネークケースのテスト
-            assert(new[] { "hoge", "fuga", "piyo" }, "hoge_fuga_piyo");
-            assert(new[] { "HOGE", "FUGA", "PIYO" }, "HOGE_FUGA_PIYO");
-            assert(new[] { "hoge", "f", "piyo" }, "hoge_f_piyo");
-            assert(new[] { "hoge", "F", "piyo" }, "hoge_F_piyo");
-            assert(new[] { "HOGE", "1", "FUGA", "PIYO" }, "HOGE_1FUGA_PIYO");
-            assert(new[] { "HOGE", "FU1GA", "PIYO" }, "HOGE_FU1GA_PIYO");
-            assert(new[] { "HOGE", "FUGA1", "PIYO" }, "HOGE_FUGA1_PIYO");
+                // MEMO : スネークケースのテスト
+                assert(new[] { "hoge", "fuga", "piyo" }, "hoge_fuga_piyo");
+                assert(new[] { "HOGE", "FUGA", "PIYO" }, "HOGE_FUGA_PIYO");
+                assert(new[] { "hoge", "f", "piyo" }, "hoge_f_piyo");
+                assert(new[] { "hoge", "F", "piyo" }, "hoge_F_piyo");
+                assert(new[] { "HOGE", "1", "FUGA", "PIYO" }, "HOGE_1FUGA_PIYO");
+                assert(new[] { "HOGE", "FU1GA", "PIYO" }, "HOGE_FU1GA_PIYO");
+                assert(new[] { "HOGE", "FUGA1", "PIYO" }, "HOGE_FUGA1_PIYO");
 
-            // MEMO : 記号を含んだテスト
-            assert(new[] { "Hoge", "Fuga", "Piyo" }, "Hoge+Fuga-Piyo");
-            assert(new[] { "Hoge", "Fuga", "Piyo" }, "Hoge+Fuga-Piyo*");
-            assert(new[] { "Hoge", "Fuga", "Piyo" }, "+Hoge-Fuga*Piyo");
-            assert(new[] { "Hoge", "Fuga", "Piyo" }, "Hoge+-Fuga**Piyo");
+                // MEMO : 記号を含んだテスト
+                assert(new[] { "Hoge", "Fuga", "Piyo" }, "Hoge+Fuga-Piyo");
+                assert(new[] { "Hoge", "Fuga", "Piyo" }, "Hoge+Fuga-Piyo*");
+                assert(new[] { "Hoge", "Fuga", "Piyo" }, "+Hoge-Fuga*Piyo");
+                assert(new[] { "Hoge", "Fuga", "Piyo" }, "Hoge+-Fuga**Piyo");
 
-            // MEMO : 単語がない場合のテスト
-            assert(new string[0], null);
-            assert(new string[0], string.Empty);
-            assert(new string[0], " ");
-            assert(new string[0], "+-*");
+                // MEMO : 単語がない場合のテスト
+                assert(new string[0], null);
+                assert(new string[0], string.Empty);
+                assert(new string[0], " ");
+                assert(new string[0], "+-*");
+            }
         }
     }
 }

--- a/Test.CaseConverter/Converters/StringCaseConverterTest.cs
+++ b/Test.CaseConverter/Converters/StringCaseConverterTest.cs
@@ -43,6 +43,36 @@ namespace Test.CaseConverter.Converters
         }
 
         [TestMethod]
+        public void ConvertTestTR()
+        {
+            using (new CultureInfoContext("tr-TR"))
+            {
+                var convertPatterns = new List<StringCasePattern>
+                {
+                    StringCasePattern.CamelCase,
+                    StringCasePattern.PascalCase,
+                    StringCasePattern.SnakeCase
+                };
+
+                Action<string, string> assert = (expected, source) =>
+                    Assert.AreEqual(expected, StringCaseConverter.Convert(source, convertPatterns));
+
+                assert("saçımŞekilÖnümdenÇekil", "saçım_şekil_önümden_çekil");
+                assert("SaçımŞekilÖnümdenÇekil", "saçımŞekilÖnümdenÇekil");
+                assert("saçım_şekil_önümden_çekil", "SaçımŞekilÖnümdenÇekil");
+
+                assert(null, null);
+                assert(string.Empty, string.Empty);
+                assert(" ", " ");
+                assert("123", "123");
+                assert("+-*", "+-*");
+
+                Assert.AreEqual("saçım_şekil_önümden_çekil", StringCaseConverter.Convert("saçım_şekil_önümden_çekil", null));
+                Assert.AreEqual("saçım_şekil_önümden_çekil", StringCaseConverter.Convert("saçım_şekil_önümden_çekil", new List<StringCasePattern>()));
+            }
+        }
+
+        [TestMethod]
         public void GetCasePatternTest()
         {
             using (new CultureInfoContext("en-US"))
@@ -78,6 +108,47 @@ namespace Test.CaseConverter.Converters
                 assert(StringCasePattern.SnakeCase, "_Ho_");
                 assert(StringCasePattern.ScreamingSnakeCase, "_H_");
                 assert(StringCasePattern.SnakeCase, "_h-");
+
+                assert(StringCasePattern.CamelCase, string.Empty);
+            }
+        }
+
+        [TestMethod]
+        public void GetCasePatternTestTR()
+        {
+            using (new CultureInfoContext("tr-TR"))
+            {
+                Action<StringCasePattern, string> assert = (expected, source) =>
+                    Assert.AreEqual(expected, StringCaseConverter.GetCasePattern(source));
+
+                assert(StringCasePattern.CamelCase, "saçımŞekilÖnümdenÇekil");
+                assert(StringCasePattern.PascalCase, "SaçımŞekilÖnümdenÇekil");
+                assert(StringCasePattern.SnakeCase, "saçım_şekil_önümden_çekil");
+                assert(StringCasePattern.PascalSnakeCase, "Saçım_Şekil_Önümden_Çekil");
+                assert(StringCasePattern.ScreamingSnakeCase, "SAÇIM_ŞEKİL_ÖNÜMDEN_ÇEKİL");
+                assert(StringCasePattern.KebabCase, "saçım-şekil-önümden-çekil");
+
+                assert(StringCasePattern.CamelCase, "şekil");
+                assert(StringCasePattern.PascalCase, "Şekil");
+                assert(StringCasePattern.ScreamingSnakeCase, "ŞEKİL");
+
+                assert(StringCasePattern.CamelCase, "i");
+                assert(StringCasePattern.PascalCase, "İ");
+
+                assert(StringCasePattern.SnakeCase, "_");
+                assert(StringCasePattern.KebabCase, "-");
+                assert(StringCasePattern.CamelCase, "=");
+
+                assert(StringCasePattern.SnakeCase, "h_");
+                assert(StringCasePattern.SnakeCase, "i_Ş");
+                assert(StringCasePattern.PascalSnakeCase, "Şi_");
+                assert(StringCasePattern.ScreamingSnakeCase, "Ş_");
+                assert(StringCasePattern.KebabCase, "Ş-");
+
+                assert(StringCasePattern.SnakeCase, "_i_");
+                assert(StringCasePattern.SnakeCase, "_Şi_");
+                assert(StringCasePattern.ScreamingSnakeCase, "_İ_");
+                assert(StringCasePattern.SnakeCase, "_i-");
 
                 assert(StringCasePattern.CamelCase, string.Empty);
             }
@@ -131,6 +202,63 @@ namespace Test.CaseConverter.Converters
                 assert(new[] { "Hoge", "Fuga", "Piyo" }, "Hoge+Fuga-Piyo*");
                 assert(new[] { "Hoge", "Fuga", "Piyo" }, "+Hoge-Fuga*Piyo");
                 assert(new[] { "Hoge", "Fuga", "Piyo" }, "Hoge+-Fuga**Piyo");
+
+                // MEMO : 単語がない場合のテスト
+                assert(new string[0], null);
+                assert(new string[0], string.Empty);
+                assert(new string[0], " ");
+                assert(new string[0], "+-*");
+            }
+        }
+
+        [TestMethod]
+        public void GetWordsTestTR()
+        {
+            using (new CultureInfoContext("tr-TR"))
+            {
+                Action<string[], string> assert = (expected, source) =>
+                    CollectionAssert.AreEquivalent(expected, StringCaseConverter.GetWords(source).ToArray());
+
+                assert(new[] { "Saçım", "Şekil", "Önümden", "Çekil" }, "SaçımŞekilÖnümdenÇekil");
+                assert(new[] { "saçım", "Şekil", "Önümden", "Çekil" }, "saçımŞekilÖnümdenÇekil");
+                assert(new[] { "SAÇIM", "Şekil", "Önümden", "Çekil" }, "SAÇIMŞekilÖnümdenÇekil");
+                assert(new[] { "Saçım", "Şekil", "Önümden", "ÇEKİL" }, "SaçımŞekilÖnümdenÇEKİL");
+                assert(new[] { "Saçım", "Şekil", "Önümden", "Ç" }, "SaçımŞekilÖnümdenÇ");
+
+                // MEMO : 数字を含んだテスト
+                assert(new[] { "Saçım", "Şe1kil", "Önümden" }, "SaçımŞe1kilÖnümden");
+                assert(new[] { "sa1çım2", "Şekil", "Önümden" }, "sa1çım2ŞekilÖnümden");
+                assert(new[] { "Saçım", "Şekil1", "ÖN2ÜMDEN3" }, "SaçımŞekil1ÖN2ÜMDEN3");
+                assert(new[] { "Saçım", "ŞE1KİL", "Önümden" }, "SaçımŞE1KİLÖnümden");
+                assert(new[] { "123" }, "123");
+
+                // MEMO : 1単語のテスト
+                assert(new[] { "şekil" }, "şekil");
+                assert(new[] { "ŞEKİL" }, "ŞEKİL");
+                assert(new[] { "şe1kil2" }, "şe1kil2");
+                assert(new[] { "1şekil" }, "1şekil");
+                assert(new[] { "1", "ŞEKİL" }, "1ŞEKİL");
+
+                // MEMO : 空白を含んだテスト
+                assert(new[] { "Saçım", "Şekil", "Önümden" }, "Saçım Şekil Önümden");
+                assert(new[] { "Saçım", "Şekil", "Önümden" }, "Saçım ŞekilÖnümden");
+                assert(new[] { "saçım", "şekil", "Önümden" }, "saçım şekil Önümden");
+                assert(new[] { "saçım", "şekil", "Önümden" }, "saçım şekilÖnümden");
+
+                // MEMO : スネークケースのテスト
+                assert(new[] { "saçım", "şekil", "önümden" }, "saçım_şekil_önümden");
+                assert(new[] { "SAÇIM", "ŞEKİL", "ÖNÜMDEN" }, "SAÇIM_ŞEKİL_ÖNÜMDEN");
+                assert(new[] { "saçım", "ş", "önümden" }, "saçım_ş_önümden");
+                assert(new[] { "saçım", "Ş", "önümden" }, "saçım_Ş_önümden");
+                assert(new[] { "SAÇIM", "1", "ŞEKİL", "ÖNÜMDEN" }, "SAÇIM_1ŞEKİL_ÖNÜMDEN");
+                assert(new[] { "SAÇIM", "ŞE1KİL", "ÖNÜMDEN" }, "SAÇIM_ŞE1KİL_ÖNÜMDEN");
+                assert(new[] { "SAÇIM", "ŞEKİL1", "ÖNÜMDEN" }, "SAÇIM_ŞEKİL1_ÖNÜMDEN");
+
+                // MEMO : 記号を含んだテスト
+                assert(new[] { "Saçım", "Şekil", "Önümden" }, "Saçım+Şekil-Önümden");
+                assert(new[] { "Saçım", "Şekil", "Önümden" }, "Saçım+Şekil-Önümden*");
+                assert(new[] { "Saçım", "Şekil", "Önümden" }, "+Saçım-Şekil*Önümden");
+                assert(new[] { "Saçım", "Şekil", "Önümden" }, "Saçım+-Şekil**Önümden");
 
                 // MEMO : 単語がない場合のテスト
                 assert(new string[0], null);

--- a/Test.CaseConverter/CultureInfoContext.cs
+++ b/Test.CaseConverter/CultureInfoContext.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Globalization;
+using System.Threading;
+
+namespace Test.CaseConverter
+{
+    internal class CultureInfoContext : IDisposable
+    {
+        private readonly CultureInfo _previousCultureInfo;
+
+        public CultureInfoContext(int cultureInfoId) : this(new CultureInfo(cultureInfoId)) { }
+
+        public CultureInfoContext(string cultureInfoName) : this(new CultureInfo(cultureInfoName)) { }
+
+        public CultureInfoContext(CultureInfo cultureInfo)
+        {
+            _previousCultureInfo = Thread.CurrentThread.CurrentCulture;
+            Thread.CurrentThread.CurrentCulture = cultureInfo;
+        }
+
+        public void Dispose()
+        {
+            Thread.CurrentThread.CurrentCulture = _previousCultureInfo;
+        }
+    }
+}

--- a/Test.CaseConverter/Test.CaseConverter.csproj
+++ b/Test.CaseConverter/Test.CaseConverter.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Converters\ScreamingSnakeCaseConverterTest.cs" />
     <Compile Include="Converters\PascalSnakeCaseConverterTest.cs" />
     <Compile Include="Converters\KebabCaseConverterTest.cs" />
+    <Compile Include="CultureInfoContext.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utils\StringUtilTest.cs" />
   </ItemGroup>


### PR DESCRIPTION
First of all thanks for this extension, it's really helpful. I'd like to change a few things if that's all right with you.

The first problem I saw after cloning the project was that the tests were failing because I use Turkish locale settings in my computer. Anyway, the short explanation is `Upper(i)` is not `I` in Turkish, it's actually `İ`. More info [here](https://blog.codinghorror.com/whats-wrong-with-turkey/) if you're interested. So the first modification (9f60198) I did was to use `en-US` culture in all existing test methods.

The other modification (2c662df) is related to the word extraction algorithm. You've used `a-z` character ranges but this range does not include language specific letters (`ş, ç, ö, ğ, ı` for Turkish) so I've changed all those character ranges with [unicode categories](http://www.regular-expressions.info/unicode.html).