### PR TITLE
Added Pascal case "with spaces"

### DIFF
--- a/CaseConverter/CaseConverter.csproj
+++ b/CaseConverter/CaseConverter.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Converters\ICaseConverter.cs" />
     <Compile Include="Converters\PascalCaseConverter.cs" />
     <Compile Include="Converters\ScreamingSnakeCaseConverter.cs" />
+    <Compile Include="Converters\SpacedPascalCaseConverter.cs" />
     <Compile Include="Converters\SnakeCaseConverter.cs" />
     <Compile Include="Options\GeneralOption.cs" />
     <Compile Include="Options\GeneralOptionPage.cs">

--- a/CaseConverter/Converters/SpacedPascalCaseConverter.cs
+++ b/CaseConverter/Converters/SpacedPascalCaseConverter.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using CaseConverter.Utils;
+
+namespace CaseConverter.Converters
+{
+    /// <summary>
+    /// 文字列をスネークケースに変換するクラスです。
+    /// </summary>
+    public class SpacedPascalCaseConverter : ICaseConverter
+    {
+        /// <inheritdoc />
+        public string Convert(IEnumerable<string> words)
+        {
+            if (words == null)
+            {
+                return string.Empty;
+            }
+
+            return string.Join(" ", words.Select(StringUtil.ToFirstUpper));
+        }
+    }
+}

--- a/CaseConverter/Converters/StringCaseConverter.cs
+++ b/CaseConverter/Converters/StringCaseConverter.cs
@@ -21,7 +21,8 @@ namespace CaseConverter.Converters
                 [StringCasePattern.SnakeCase] = new SnakeCaseConverter(),
                 [StringCasePattern.PascalSnakeCase] = new PascalSnakeCaseConverter(),
                 [StringCasePattern.ScreamingSnakeCase] = new ScreamingSnakeCaseConverter(),
-                [StringCasePattern.KebabCase] = new KebabCaseConverter()
+                [StringCasePattern.KebabCase] = new KebabCaseConverter(),
+                [StringCasePattern.SpacedPascalCase] = new SpacedPascalCaseConverter()
             };
 
         /// <summary>
@@ -83,6 +84,10 @@ namespace CaseConverter.Converters
             else if (input.Contains('-'))
             {
                 return StringCasePattern.KebabCase;
+            }
+            else if (input.Contains(' '))
+            {
+                return StringCasePattern.SpacedPascalCase;
             }
             else if (char.IsUpper(input[0]))
             {

--- a/CaseConverter/Converters/StringCasePattern.cs
+++ b/CaseConverter/Converters/StringCasePattern.cs
@@ -33,6 +33,11 @@
         /// <summary>
         /// ケバブケースです。
         /// </summary>
-        KebabCase
+        KebabCase,
+
+        /// <summary>
+        /// スペースを含むパスカルケース。
+        /// </summary>
+        SpacedPascalCase
     }
 }

--- a/CaseConverter/Options/StringCasePatternConverter.cs
+++ b/CaseConverter/Options/StringCasePatternConverter.cs
@@ -22,7 +22,8 @@ namespace CaseConverter.Options
             [StringCasePattern.SnakeCase] = "snake_case",
             [StringCasePattern.PascalSnakeCase] = "Pascal_Snake_Case",
             [StringCasePattern.ScreamingSnakeCase] = "SCREAMING_SNAKE_CASE",
-            [StringCasePattern.KebabCase] = "kebab-case"
+            [StringCasePattern.KebabCase] = "kebab-case",
+            [StringCasePattern.SpacedPascalCase] = "Spaced Pascal Case"
         };
 
         /// <summary>

--- a/Test.CaseConverter/Converters/SpacedPascalCaseConverterTest.cs
+++ b/Test.CaseConverter/Converters/SpacedPascalCaseConverterTest.cs
@@ -1,0 +1,18 @@
+﻿using CaseConverter.Converters;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Test.CaseConverter.Converters
+{
+    /// <summary>
+    /// <see cref="SpacedPascalCaseConverterTest"/>のテストクラスです。
+    /// </summary>
+    [TestClass]
+    public class SpacedPascalCaseConverterTest : CaseConverterTestBase<SpacedPascalCaseConverter>
+    {
+        [TestMethod]
+        public void ConvertTest()
+        {
+            ConvertTest("Hoge Fuga Piyo", "Hoge", "H");
+        }
+    }
+}

--- a/Test.CaseConverter/Test.CaseConverter.csproj
+++ b/Test.CaseConverter/Test.CaseConverter.csproj
@@ -59,6 +59,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="Converters\CaseConverterTestBase.cs" />
+    <Compile Include="Converters\SpacedPascalCaseConverterTest.cs" />
     <Compile Include="Converters\StringCaseConverterTest.cs" />
     <Compile Include="Converters\CamelCaseConverterTest.cs" />
     <Compile Include="Converters\PascalCaseConverterTest.cs" />


### PR DESCRIPTION
In a project I work on we have unit test method names in PascalSnakeCase but the display names in what can be described as spaced Pascal case. 

Example:
```
[Fact(DisplayName="Invalid Input Should Throw")]
Invalid_Input_Should_Throw
...
```

Out of laziness I wanted to take `Invalid_Input_Should_Throw` and convert that to `Invalid Input Should Throw`